### PR TITLE
Sage-1126: WSN GPU Stress / Thermal Test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM waggle/plugin-torch:1.4.0
+FROM nvcr.io/nvidia/l4t-ml:r32.4.3-py3
 
 COPY . .
 
-ENTRYPOINT [ "python3", "stress.py" ]
+ENTRYPOINT [ "python3", "stress.py"]
+CMD ["-m 1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM nvcr.io/nvidia/l4t-ml:r32.4.3-py3
+FROM waggle/plugin-base:1.1.1-ml
 
 COPY . .
 
 ENTRYPOINT [ "python3", "stress.py"]
-CMD ["-m 1"]
+CMD ["-m 5"]

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This is a simple piece of PyTorch code to stress test a GPU.
 ## Buildx building and pushing to Dockerhub
 
 ```
-docker buildx build -t iperezx/gpu-stress-test:latest --platform linux/amd64,linux/arm64 --push .
+docker buildx build -t waggle/gpu-stress-test:latest --platform linux/amd64,linux/arm64 --push .
 ```
 
 ## Build and run on device
 ```
-docker build -t iperezx/gpu-stress-test:latest .
+docker build -t waggle/gpu-stress-test:latest .
 ```
 The docker has an entrypoint and a default value in the cmd. The python script expects to be pass in the number of minutes to run the stress test. 
 Python usage:
@@ -19,16 +19,16 @@ python stress.py -m 1
 ```
 Docker usage:
 ```
-docker run -it --rm --runtime nvidia --network host iperezx/gpu-stress-test:latest
+docker run -it --rm --runtime nvidia --network host waggle/gpu-stress-test:latest
 ```
 Docker usage with changing the number of minutes to 2:
 ```
-docker run -it --rm --runtime nvidia --network host iperezx/gpu-stress-test:latest -m 2
+docker run -it --rm --runtime nvidia --network host waggle/gpu-stress-test:latest -m 2
 ```
 
 Push image to Dockerhub:
 ```
-docker push iperezx/gpu-stress-test:latest
+docker push waggle/gpu-stress-test:latest
 ```
 
 ## Kubernetes Cronjob
@@ -51,4 +51,3 @@ Delete cronjob:
 ```
 kubectl delete -f cronjob.yaml
 ```
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a simple piece of PyTorch code to stress test a GPU.
 ## Buildx building and pushing to Dockerhub
 
 ```
-docker buildx build -t iperezx/gpu-stress-test:latest --platform linux/amd64,linux/arm/v7,linux/arm64 --push .
+docker buildx build -t iperezx/gpu-stress-test:latest --platform linux/amd64,linux/arm64 --push .
 ```
 
 ## Build and run on device

--- a/README.md
+++ b/README.md
@@ -2,13 +2,53 @@
 
 This is a simple piece of PyTorch code to stress test a GPU.
 
-## Building and Pushing to Dockerhub
+## Buildx building and pushing to Dockerhub
 
-```sh
-docker buildx build -t waggle/gpu-stress-test --platform linux/amd64,linux/arm/v7,linux/arm64 --push .
+```
+docker buildx build -t iperezx/gpu-stress-test:latest --platform linux/amd64,linux/arm/v7,linux/arm64 --push .
 ```
 
-*Note*: Building on MacOS resulted in the following error
-(`failed to solve: rpc error: code = Unknown desc = failed to copy: unexpected EOF`) when
-building the `linux/arm64` platform. This was resolved by building and pushing on
-a true Ubuntu:18.04 host.
+## Build and run on device
+```
+docker build -t iperezx/gpu-stress-test:latest .
+```
+The docker has an entrypoint and a default value in the cmd. The python script expects to be pass in the number of minutes to run the stress test. 
+Python usage:
+```
+python stress.py -m 1
+```
+Docker usage:
+```
+docker run -it --rm --runtime nvidia --network host iperezx/gpu-stress-test:latest
+```
+Docker usage with changing the number of minutes to 2:
+```
+docker run -it --rm --runtime nvidia --network host iperezx/gpu-stress-test:latest -m 2
+```
+
+Push image to Dockerhub:
+```
+docker push iperezx/gpu-stress-test:latest
+```
+
+## Kubernetes Cronjob
+The cronjob is meant to run the gpu stress in a periodic fashion.
+```
+kubectl create -f cronjob.yaml
+```
+
+Check if it was created:
+```
+kubectl get cronjobs
+```
+
+Watch until one is created:
+```
+kubectl get jobs --watch
+```
+
+Delete cronjob:
+```
+kubectl delete -f cronjob.yaml
+```
+

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
                     - "true"
           containers:
           - name: gpu-stress-test
-            image: iperezx/gpu-stress-test:latest 
+            image: waggle/gpu-stress-test:latest
             imagePullPolicy: IfNotPresent
             args: ["-m 5"]
           restartPolicy: OnFailure

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: gpu-stress-test
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "*/30 * * * *"
   jobTemplate:
     spec:
       template:
@@ -22,5 +22,5 @@ spec:
             image: iperezx/gpu-stress-test:latest 
             imagePullPolicy: IfNotPresent
             command:
-            - -m 1
+            - -m 5
           restartPolicy: OnFailure

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -8,6 +8,15 @@ spec:
     spec:
       template:
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: resource.gpu
+                    operator: In
+                    values:
+                    - "true"
           containers:
           - name: gpu-stress-test
             image: iperezx/gpu-stress-test:latest 

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -21,6 +21,5 @@ spec:
           - name: gpu-stress-test
             image: iperezx/gpu-stress-test:latest 
             imagePullPolicy: IfNotPresent
-            command:
-            - -m 5
+            args: ["-m 5"]
           restartPolicy: OnFailure

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: gpu-stress-test
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: gpu-stress-test
+            image: iperezx/gpu-stress-test:latest 
+            imagePullPolicy: IfNotPresent
+            command:
+            - -m 1
+          restartPolicy: OnFailure

--- a/stress.py
+++ b/stress.py
@@ -1,6 +1,20 @@
 import torch
+import time
+import argparse
+import sys
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-m", "--Minutes", help = "Number of minutes to run the stress test")
+args = parser.parse_args()
+
+num_minutes = float(args.Minutes)
 
 x = torch.linspace(0, 4, 16*1024**2).cuda()
 
+timeout = time.time() + 60*num_minutes   # 5 minutes from now
+
 while True:
     x = x * (1.0 - x)
+    if time.time() > timeout:
+        sys.exit(os.EX_OK)

--- a/stress.py
+++ b/stress.py
@@ -12,7 +12,7 @@ num_minutes = float(args.Minutes)
 
 x = torch.linspace(0, 4, 16*1024**2).cuda()
 
-timeout = time.time() + 60*num_minutes   # 5 minutes from now
+timeout = time.time() + 60*num_minutes
 
 while True:
     x = x * (1.0 - x)


### PR DESCRIPTION
Update GPU stress test. 
Defaults to run for 1 minute in 10 minute intervals.
`cronjob.yaml` can be modified to change the default settings.

Node affinity is also set to only target the device with a GPU:
`resource.gpu: true`