### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ FROM waggle/plugin-base:1.1.1-ml
 COPY . .
 
 ENTRYPOINT [ "python3", "stress.py"]
-CMD ["-m 5"]
+# Updating the number of seconds to run a gpu burn test.
+# the -m 5 is no longe accurate
+CMD [" 300"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . .
 ENTRYPOINT [ "python3", "stress.py"]
 # Updating the number of seconds to run a gpu burn test.
 # the -m 5 is no longe accurate
-CMD [" 300"]
+CMD ["-r 300"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY . .
 
 ENTRYPOINT [ "python3", "stress.py"]
 # Updating the number of seconds to run a gpu burn test.
-# the -m 5 is no longe accurate
+# the -m 5 is no longer accurate
 CMD ["-r 300"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run -it --rm --runtime nvidia --network host waggle/gpu-stress-test:lates
 
 Over-ride run-time to 2 minutes:
 ```bash
-docker run -it --rm --runtime nvidia --network host waggle/gpu-stress-test:latest -m 2
+docker run -it --rm --runtime nvidia --network host waggle/gpu-stress-test:latest -r 120
 ```
 
 ### Kubernetes Usage
@@ -43,7 +43,7 @@ pluginctl deploy --name gpu-test2 --selector resource.gpu=true waggle/gpu-stress
 
 Over-ride run-time to 1 minute:
 ```bash
-pluginctl deploy --name gpu-test2 --selector resource.gpu=true waggle/gpu-stress-test:1.0.0 -- -m 1
+pluginctl deploy --name gpu-test2 --selector resource.gpu=true waggle/gpu-stress-test:1.0.0 -- -r 60
 ```
 
 > Note: the source code for the Waggle `pluginctl` tool can be found here: https://github.com/waggle-sensor/edge-scheduler


### PR DESCRIPTION
the stress.py does not have an "m" parameter , the runtime in seconds is the only direct int value that can be passed
We also need to update the docs to allow for this parameter 